### PR TITLE
ci/cd: create artifact for PRs

### DIFF
--- a/.github/workflows/pull_request_v0.23.yaml
+++ b/.github/workflows/pull_request_v0.23.yaml
@@ -1,0 +1,48 @@
+name: Pull Request for vaccel-v0.23
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        build_type: [debug, release]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build Firecracker
+        run: ./tools/devtool -y build -l gnu --${{ matrix.build_type}}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact/@v2
+        with:
+          name: firecracker-${{ github.event.pull_request.head.sha }}-${{ matrix.build_type }}
+          path: build/cargo_target/x86_64-unknown-linux-gnu/${{ matrix.build_type }}/firecracker
+
+  upload_artifact:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: minio/mc
+      env:
+        NBFC_S3_ACCESS: ${{ secrets.AWS_ACCESS_KEY }}
+        NBFC_S3_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    strategy:
+      matrix:
+        build_type: [debug, release]
+
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: firecracker-${{ github.event.pull_request.head.sha }}-${{ matrix.build_type }}
+
+    - name: Upload artifact to s3
+      run: |
+        mc alias set nbfc-rook https://s3.nubificus.co.uk $NBFC_S3_ACCESS $NBFC_S3_SECRET
+        mc cp firecracker nbfc-rook/nbfc-assets/github/firecracker/${{ github.event.pull_request.head.sha }}/${{ matrix.build_type}}/firecracker


### PR DESCRIPTION
To assist continuous integration and testing we want to create a
firecracker binary to test from every time we open a PR to our latest
development branch.

For every PR, a Github Action will run that builds Firecracker and
uploads it to our s3

Signed-off-by: Babis Chalios <mail@bchalios.io>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

- [ ] This functionality can be added in [`rust-vmm`](https://github.com/rust-vmm).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any API changes are reflected in `firecracker/swagger.yaml`.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
