### PR TITLE
Vaccel 0.23 extend

### DIFF
--- a/.github/workflows/create_image.yml
+++ b/.github/workflows/create_image.yml
@@ -1,0 +1,43 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ vaccel-0.23, vaccel-0.23-extend ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: [self-hosted, "${{ matrix.arch }}" ]
+    strategy:
+      matrix: 
+        arch: [X64, aarch64]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@main
+
+    - name: Set Dockerfile name & Tags
+      id: set-dockerfile-name
+      run: |
+        if [[ "${{ matrix.arch }}" == "X64" ]]
+        then
+          Dockerfile="${{github.workspace}}/tools/devctr/Dockerfile.x86_64"
+          tag="x86_64"
+          echo "::set-output name=dfile::$Dockerfile"
+          echo "::set-output name=atag::$tag"
+        else
+          Dockerfile="${{github.workspace}}/tools/devctr/Dockerfile.aarch64"
+          tag="arm64"
+          echo "::set-output name=dfile::$Dockerfile"
+          echo "::set-output name=atag::$tag"
+        fi
+
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name:  nubificus/fcuvm
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "${{ steps.set-dockerfile-name.outputs.atag }}"
+        dockerfile: ${{ steps.set-dockerfile-name.outputs.dfile }}

--- a/.github/workflows/create_image.yml
+++ b/.github/workflows/create_image.yml
@@ -45,7 +45,7 @@ jobs:
         dockerfile: ${{ steps.set-dockerfile-name.outputs.dfile }}
 
   manifest:
-    runs-on: self-hosted
+    runs-on: [ self-hosted, aarch64 ]
     needs: build
     steps:
       - name: Login to dockerhub

--- a/.github/workflows/create_image.yml
+++ b/.github/workflows/create_image.yml
@@ -3,6 +3,8 @@ name: Docker Image CI
 on:
   push:
     branches: [ vaccel-0.23, vaccel-0.23-extend ]
+    paths:
+      - '**/Dockerfile*'
   pull_request:
     branches: [ master ]
 
@@ -41,3 +43,21 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         tags: "${{ steps.set-dockerfile-name.outputs.atag }}"
         dockerfile: ${{ steps.set-dockerfile-name.outputs.dfile }}
+
+  manifest:
+    runs-on: self-hosted
+    needs: build
+    steps:
+      - name: Login to dockerhub
+        id: login
+        run: |
+          docker login -u $DUSR -p $DPSWD
+        env:
+          DUSR: ${{ secrets.DOCKER_USERNAME }}
+          DPSWD: ${{ secrets.DOCKER_PASSWORD }}
+        
+      - name: Manifest images under one label
+        id: manifest-images
+        run: |
+          docker manifest create nubificus/fcuvm:vaccel --amend nubificus/fcuvm:x86_64 --amend nubificus/fcuvm:arm64
+          docker manifest push nubificus/fcuvm:vaccel

--- a/.github/workflows/pull_request_v0.23.yaml
+++ b/.github/workflows/pull_request_v0.23.yaml
@@ -1,8 +1,6 @@
 name: Pull Request for vaccel-v0.23
 
 on:
-  push:
-    branches: [ vaccel-0.23, vaccel-0.23-extend ]
   pull_request:
    
 

--- a/.github/workflows/pull_request_v0.23.yaml
+++ b/.github/workflows/pull_request_v0.23.yaml
@@ -31,4 +31,4 @@ jobs:
           access-key: ${{ secrets.AWS_ACCESS_KEY }}
           secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           local-path: build/cargo_target/${{ matrix.arch }}-unknown-linux-gnu/${{ matrix.build_type }}/firecracker
-          remote-path: nbfc-assets/github/firecracker/${{ matrix.arch }}/${{ matrix.build_type}}/
+          remote-path: nbfc-assets/github/firecracker/${{ github.event.pull_request.head.sha }}/${{ matrix.arch }}/${{ matrix.build_type}}/

--- a/.github/workflows/pull_request_v0.23.yaml
+++ b/.github/workflows/pull_request_v0.23.yaml
@@ -1,14 +1,19 @@
 name: Pull Request for vaccel-v0.23
 
-on: [pull_request]
+on:
+  push:
+    branches: [ vaccel-0.23, vaccel-0.23-extend ]
+  pull_request:
+   
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: [self-hosted, "${{ matrix.arch }}" ]
     strategy:
       matrix:
+        arch: [x86_64, aarch64]
         build_type: [debug, release]
+      fail-fast: false
 
     steps:
       - name: Checkout code
@@ -20,8 +25,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact/@v2
         with:
-          name: firecracker-${{ github.event.pull_request.head.sha }}-${{ matrix.build_type }}
-          path: build/cargo_target/x86_64-unknown-linux-gnu/${{ matrix.build_type }}/firecracker
+          name: firecracker-${{ github.event.pull_request.head.sha }}-${{ matrix.arch }}-${{ matrix.build_type }}
+          path: build/cargo_target/${{ matrix.arch }}-unknown-linux-gnu/${{ matrix.build_type }}/firecracker
 
   upload_artifact:
     needs: build
@@ -34,15 +39,17 @@ jobs:
 
     strategy:
       matrix:
+        arch: [x86_64, aarch64]
         build_type: [debug, release]
+      fail-fast: false
 
     steps:
     - name: Download artifact
       uses: actions/download-artifact@v2
       with:
-        name: firecracker-${{ github.event.pull_request.head.sha }}-${{ matrix.build_type }}
+        name: firecracker-${{ github.event.pull_request.head.sha }}-${{ matrix.arch }}-${{ matrix.build_type }}
 
     - name: Upload artifact to s3
       run: |
         mc alias set nbfc-rook https://s3.nubificus.co.uk $NBFC_S3_ACCESS $NBFC_S3_SECRET
-        mc cp firecracker nbfc-rook/nbfc-assets/github/firecracker/${{ github.event.pull_request.head.sha }}/${{ matrix.build_type}}/firecracker
+        mc cp firecracker nbfc-rook/nbfc-assets/github/firecracker/${{ github.event.pull_request.head.sha }}/${{ matrix.arch }}/${{ matrix.build_type}}/firecracker

--- a/.github/workflows/pull_request_v0.23.yaml
+++ b/.github/workflows/pull_request_v0.23.yaml
@@ -30,5 +30,5 @@ jobs:
           url: https://s3.nubificus.co.uk
           access-key: ${{ secrets.AWS_ACCESS_KEY }}
           secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          local-path: build/cargo_target/${{ matrix.arch }}-unknown-linux-gnu/${{ matrix.build_type }}
+          local-path: build/cargo_target/${{ matrix.arch }}-unknown-linux-gnu/${{ matrix.build_type }}/firecracker
           remote-path: nbfc-assets/github/firecracker/${{ matrix.arch }}/${{ matrix.build_type}}/

--- a/.github/workflows/pull_request_v0.23.yaml
+++ b/.github/workflows/pull_request_v0.23.yaml
@@ -22,34 +22,13 @@ jobs:
       - name: Build Firecracker
         run: ./tools/devtool -y build -l gnu --${{ matrix.build_type}}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact/@v2
+      - name: Upload Kernel artifact
+        id: upload-artifact
+        if: steps.build-kernel.outputs.build_exit_code == 0
+        uses: cloudkernels/minio-upload@master
         with:
-          name: firecracker-${{ github.event.pull_request.head.sha }}-${{ matrix.arch }}-${{ matrix.build_type }}
-          path: build/cargo_target/${{ matrix.arch }}-unknown-linux-gnu/${{ matrix.build_type }}/firecracker
-
-  upload_artifact:
-    needs: build
-    runs-on: ubuntu-latest
-    container:
-      image: minio/mc
-      env:
-        NBFC_S3_ACCESS: ${{ secrets.AWS_ACCESS_KEY }}
-        NBFC_S3_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-    strategy:
-      matrix:
-        arch: [x86_64, aarch64]
-        build_type: [debug, release]
-      fail-fast: false
-
-    steps:
-    - name: Download artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: firecracker-${{ github.event.pull_request.head.sha }}-${{ matrix.arch }}-${{ matrix.build_type }}
-
-    - name: Upload artifact to s3
-      run: |
-        mc alias set nbfc-rook https://s3.nubificus.co.uk $NBFC_S3_ACCESS $NBFC_S3_SECRET
-        mc cp firecracker nbfc-rook/nbfc-assets/github/firecracker/${{ github.event.pull_request.head.sha }}/${{ matrix.arch }}/${{ matrix.build_type}}/firecracker
+          url: https://s3.nubificus.co.uk
+          access-key: ${{ secrets.AWS_ACCESS_KEY }}
+          secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          local-path: build/cargo_target/${{ matrix.arch }}-unknown-linux-gnu/${{ matrix.build_type }}
+          remote-path: nbfc-assets/github/firecracker/${{ matrix.arch }}/${{ matrix.build_type}}/

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -81,7 +81,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION_TAG}/tini-s
 RUN chmod +x /sbin/tini
 
 # Install vaccel runtime
-RUN git clone https://github.com/cloudkernels/vaccelrt.git && \
+RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive && \
 	cd vaccelrt && \
 	mkdir build && cd build && \
 	cmake .. && make -C src install

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -90,7 +90,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION_TAG}/tini-s
 RUN chmod +x /sbin/tini
 
 # Install vaccel runtime
-RUN git clone https://github.com/cloudkernels/vaccelrt.git && \
+RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive && \
 	cd vaccelrt && \
 	mkdir build && cd build && \
 	cmake .. && make -C src install

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -76,7 +76,7 @@ RUN mkdir "$TMP_BUILD_DIR" \
         && rustup component add clippy-preview \
         && cd "$TMP_BUILD_DIR" \
             && cargo install cargo-kcov \
-            && cargo install cargo-audit \
+            && cargo install --version 0.11.0 cargo-audit \
             && cargo kcov --print-install-kcov-sh | sh \
         && rm -rf "$CARGO_HOME/registry" \
         && ln -s "$CARGO_REGISTRY_DIR" "$CARGO_HOME/registry" \

--- a/tools/devtool
+++ b/tools/devtool
@@ -73,7 +73,7 @@
 # Development container image (name:tag)
 # This should be updated whenever we upgrade the development container.
 # (Yet another step on our way to reproducible builds.)
-DEVCTR_IMAGE="nubificus/fcuvm:v0.23"
+DEVCTR_IMAGE="nubificus/fcuvm:vaccel"
 
 # Naming things is hard
 MY_NAME="Firecracker $(basename "$0")"


### PR DESCRIPTION
## Reason for This PR

Fixes #8 

## Description of Changes
-Automates the construction of the docker container images for x86_64 & aarch64 for changes in the Dockerfiles only.
-Pushes both archs under the same label via docker manifest
-Automates firecracker binaries building & uploading for pull requests (both x86 & aarch64) that will be needed for vaccel
