### PR TITLE
Add the generic operation.

### DIFF
--- a/.github/workflows/create_image.yml
+++ b/.github/workflows/create_image.yml
@@ -7,43 +7,27 @@ on:
       - '**/Dockerfile*'
   pull_request:
     branches: [ vaccel-0.23 ]
-  workflow_dispatch:  
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: [self-hosted, "${{ matrix.arch }}" ]
     strategy:
-      matrix: 
-        arch: [X64, aarch64]
+      matrix:
+        arch: [x86_64, aarch64]
       fail-fast: false
 
     steps:
     - uses: actions/checkout@main
 
-    - name: Set Dockerfile name & Tags
-      id: set-dockerfile-name
-      run: |
-        if [[ "${{ matrix.arch }}" == "X64" ]]
-        then
-          Dockerfile="${{github.workspace}}/tools/devctr/Dockerfile.x86_64"
-          tag="x86_64"
-          echo "::set-output name=dfile::$Dockerfile"
-          echo "::set-output name=atag::$tag"
-        else
-          Dockerfile="${{github.workspace}}/tools/devctr/Dockerfile.aarch64"
-          tag="arm64"
-          echo "::set-output name=dfile::$Dockerfile"
-          echo "::set-output name=atag::$tag"
-        fi
-
-    - name: Publish to Registry
+    - name: Build docker image
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name:  nubificus/fcuvm
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "${{ steps.set-dockerfile-name.outputs.atag }}"
-        dockerfile: ${{ steps.set-dockerfile-name.outputs.dfile }}
+        tags: "${{matrix.arch}}"
+        dockerfile: "${{github.workspace}}/tools/devctr/Dockerfile.${{matrix.arch}}"
 
   manifest:
     runs-on: [ self-hosted, aarch64 ]
@@ -56,9 +40,9 @@ jobs:
         env:
           DUSR: ${{ secrets.DOCKER_USERNAME }}
           DPSWD: ${{ secrets.DOCKER_PASSWORD }}
-        
+
       - name: Manifest images under one label
         id: manifest-images
         run: |
-          docker manifest create nubificus/fcuvm:vaccel --amend nubificus/fcuvm:x86_64 --amend nubificus/fcuvm:arm64
+          docker manifest create nubificus/fcuvm:vaccel --amend nubificus/fcuvm:x86_64 --amend nubificus/fcuvm:aarch64
           docker manifest push nubificus/fcuvm:vaccel

--- a/.github/workflows/create_image.yml
+++ b/.github/workflows/create_image.yml
@@ -7,6 +7,7 @@ on:
       - '**/Dockerfile*'
   pull_request:
     branches: [ vaccel-0.23 ]
+  workflow_dispatch:  
 
 jobs:
   build:

--- a/.github/workflows/create_image.yml
+++ b/.github/workflows/create_image.yml
@@ -45,5 +45,8 @@ jobs:
       - name: Manifest images under one label
         id: manifest-images
         run: |
-          docker manifest create nubificus/fcuvm:vaccel --amend nubificus/fcuvm:x86_64 --amend nubificus/fcuvm:aarch64
+          docker manifest rm nubificus/fcuvm:vaccel
+          docker manifest create nubificus/fcuvm:vaccel \
+            --amend nubificus/fcuvm:x86_64 \
+            --amend nubificus/fcuvm:aarch64
           docker manifest push nubificus/fcuvm:vaccel

--- a/.github/workflows/create_image.yml
+++ b/.github/workflows/create_image.yml
@@ -28,6 +28,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         tags: "${{matrix.arch}}"
         dockerfile: "${{github.workspace}}/tools/devctr/Dockerfile.${{matrix.arch}}"
+        buildargs: FOOLCACHE=$(date +%s)
 
   manifest:
     runs-on: [ self-hosted, aarch64 ]

--- a/.github/workflows/pull_request_v0.23.yaml
+++ b/.github/workflows/pull_request_v0.23.yaml
@@ -2,7 +2,7 @@ name: Pull Request for vaccel-v0.23
 
 on:
   pull_request:
-   
+
 
 jobs:
   build:
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Fetch latest docker image
+        run: docker pull nubificus/fcuvm:vaccel
 
       - name: Build Firecracker
         run: ./tools/devtool -y build -l gnu --${{ matrix.build_type}}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -103,7 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.65"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -252,7 +252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -337,7 +337,7 @@ name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -399,7 +399,7 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "vaccel-bindings"
 version = "0.1.0"
-source = "git+https://github.com/cloudkernels/vaccel-bindings?branch=feat_genop"
+source = "git+https://github.com/cloudkernels/vaccel-bindings?branch=feat_genop#165cc0f8c276bc813930360fb94c77a6b3d2222f"
 dependencies = [
  "bindgen 0.53.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -625,7 +625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -757,7 +757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bindgen 0.53.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-"checksum cc 1.0.65 (registry+https://github.com/rust-lang/crates.io-index)" = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
+"checksum cc 1.0.67 (registry+https://github.com/rust-lang/crates.io-index)" = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 "checksum cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
@@ -769,7 +769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-"checksum hermit-abi 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+"checksum hermit-abi 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -806,7 +806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vaccel-bindings 0.1.0 (git+https://github.com/cloudkernels/vaccel-bindings?branch=feat_genop)" = "<none>"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-"checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+"checksum version_check 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 "checksum versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9947d2d1888281839f86c26f727c5ef40accf0ef0762b3086e33a476cea858"
 "checksum versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7817377bbb6759686d790fb8fbbb22a0371521d509a21fdb125cf7c9c9d815a"
 "checksum vm-memory 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aae367b8bd176f4936b5d35c4403606d4a8458a8151dff47c974f1d9d1a4c974"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "snapshot 0.1.0",
  "timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
- "vaccel-bindings 0.1.0 (git+https://github.com/cloudkernels/vaccel-bindings?branch=feat_genop)",
+ "vaccel-bindings 0.1.0 (git+https://github.com/cloudkernels/vaccel-bindings?branch=api_cleanup)",
  "versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio_gen 0.1.0",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "vaccel-bindings"
 version = "0.1.0"
-source = "git+https://github.com/cloudkernels/vaccel-bindings?branch=feat_genop#165cc0f8c276bc813930360fb94c77a6b3d2222f"
+source = "git+https://github.com/cloudkernels/vaccel-bindings?branch=api_cleanup#187ae1dd4bf5907802b44c9854e229deca179630"
 dependencies = [
  "bindgen 0.53.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -804,7 +804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0123bba5b202eb298259401ae5611d3a34e852f1d9b6963bbf266b344355a93d"
 "checksum unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum vaccel-bindings 0.1.0 (git+https://github.com/cloudkernels/vaccel-bindings?branch=feat_genop)" = "<none>"
+"checksum vaccel-bindings 0.1.0 (git+https://github.com/cloudkernels/vaccel-bindings?branch=api_cleanup)" = "<none>"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum version_check 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 "checksum versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9947d2d1888281839f86c26f727c5ef40accf0ef0762b3086e33a476cea858"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "snapshot 0.1.0",
  "timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
- "vaccel-bindings 0.1.0 (git+https://github.com/bchalios/vaccel-bindings)",
+ "vaccel-bindings 0.1.0 (git+https://github.com/cloudkernels/vaccel-bindings?branch=feat_genop)",
  "versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "versionize_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio_gen 0.1.0",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "vaccel-bindings"
 version = "0.1.0"
-source = "git+https://github.com/bchalios/vaccel-bindings#cab1a395c9b7a64bfbf9bb826b91080fea035dd2"
+source = "git+https://github.com/cloudkernels/vaccel-bindings?branch=feat_genop"
 dependencies = [
  "bindgen 0.53.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -804,7 +804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum timerfd 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0123bba5b202eb298259401ae5611d3a34e852f1d9b6963bbf266b344355a93d"
 "checksum unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum vaccel-bindings 0.1.0 (git+https://github.com/bchalios/vaccel-bindings)" = "<none>"
+"checksum vaccel-bindings 0.1.0 (git+https://github.com/cloudkernels/vaccel-bindings?branch=feat_genop)" = "<none>"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum versionize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9947d2d1888281839f86c26f727c5ef40accf0ef0762b3086e33a476cea858"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -20,4 +20,4 @@ rate_limiter = { path = "../rate_limiter" }
 snapshot = { path = "../snapshot" }
 utils = { path = "../utils" }
 virtio_gen = { path = "../virtio_gen" }
-vaccel-bindings = { git = "https://github.com/cloudkernels/vaccel-bindings", branch = "feat_genop" }
+vaccel-bindings = { git = "https://github.com/cloudkernels/vaccel-bindings", branch = "api_cleanup" }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -20,4 +20,4 @@ rate_limiter = { path = "../rate_limiter" }
 snapshot = { path = "../snapshot" }
 utils = { path = "../utils" }
 virtio_gen = { path = "../virtio_gen" }
-vaccel-bindings = { git = "https://github.com/bchalios/vaccel-bindings", branch = "master" }
+vaccel-bindings = { git = "https://github.com/cloudkernels/vaccel-bindings", branch = "feat_genop" }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -20,4 +20,4 @@ rate_limiter = { path = "../rate_limiter" }
 snapshot = { path = "../snapshot" }
 utils = { path = "../utils" }
 virtio_gen = { path = "../virtio_gen" }
-vaccel-bindings = { git = "https://github.com/cloudkernels/vaccel-bindings", branch = "api_cleanup" }
+vaccel-bindings = { git = "https://github.com/cloudkernels/vaccel-bindings", branch = "master" }

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -81,6 +81,8 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION_TAG}/tini-s
 RUN chmod +x /sbin/tini
 
 # Install vaccel runtime
+ARG FOOLCACHE=0
+RUN echo "$FOOLCACHE"
 RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive && \
 	cd vaccelrt && \
 	mkdir build && cd build && \

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -81,7 +81,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION_TAG}/tini-s
 RUN chmod +x /sbin/tini
 
 # Install vaccel runtime
-RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive -b feat_genop && \
+RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive && \
 	cd vaccelrt && \
 	mkdir build && cd build && \
 	cmake .. && make -C src install

--- a/tools/devctr/Dockerfile.aarch64
+++ b/tools/devctr/Dockerfile.aarch64
@@ -81,7 +81,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION_TAG}/tini-s
 RUN chmod +x /sbin/tini
 
 # Install vaccel runtime
-RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive && \
+RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive -b feat_genop && \
 	cd vaccelrt && \
 	mkdir build && cd build && \
 	cmake .. && make -C src install

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -90,6 +90,8 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION_TAG}/tini-s
 RUN chmod +x /sbin/tini
 
 # Install vaccel runtime
+ARG FOOLCACHE=0
+RUN echo "$FOOLCACHE"
 RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive && \
 	cd vaccelrt && \
 	mkdir build && cd build && \

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -90,7 +90,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION_TAG}/tini-s
 RUN chmod +x /sbin/tini
 
 # Install vaccel runtime
-RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive && \
+RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive -b feat_doop && \
 	cd vaccelrt && \
 	mkdir build && cd build && \
 	cmake .. && make -C src install

--- a/tools/devctr/Dockerfile.x86_64
+++ b/tools/devctr/Dockerfile.x86_64
@@ -90,7 +90,7 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION_TAG}/tini-s
 RUN chmod +x /sbin/tini
 
 # Install vaccel runtime
-RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive -b feat_doop && \
+RUN git clone https://github.com/cloudkernels/vaccelrt.git --recursive && \
 	cd vaccelrt && \
 	mkdir build && cd build && \
 	cmake .. && make -C src install


### PR DESCRIPTION
Accompanies vAccelRT branch feat_genop@5112a04619800

VACCEL_GEN_OP is a generic operation where the frontend has a
prototype of the form:

    function(output, input, output_len, input_len);

in order to serve as a generic abstraction for any kind of
execution.

The form of input and output parameters is completely agnostic
to the framework. vAccel just forwards a call to a specific
function implemented as a plugin. The actual arguments are unpacked
in the plugin and packed in a small wrapper template in the
frontend (not included in this patchset). For clarity, the wrapper
template should be available as an example to help individuals port
their functions to vAccel.

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>
